### PR TITLE
Implement user sessions

### DIFF
--- a/Backend/lootbox.js
+++ b/Backend/lootbox.js
@@ -1,4 +1,3 @@
-import Cat from './cat.js';
 import random from "random";
 
 // Cached random distributions
@@ -38,7 +37,7 @@ export const LOOTBOX_RARITY_FUNCTIONS = [
 ]
 
 // TODO: set appropriate costs
-const LOOTBOX_COSTS = [
+export const LOOTBOX_COSTS = [
   1,
   2,
   3,
@@ -51,25 +50,4 @@ export class LootboxOpenError extends Error {
     this.message = message;
     this.name = "LootboxOpenError";
   }
-}
-
-// Buy and open a lootbox with the given ID, returning the cat gained. Box IDs go from 0-3, and 3 is most rare.
-export function buyLootbox(lootboxID, user) {
-  if (!user) {
-    throw new LootboxOpenError("Invalid user");
-  }
-  if (lootboxID < 0 || lootboxID > 3) {
-    throw new LootboxOpenError("Invalid lootbox");
-  }
-
-  // get user gems
-  const gems = user.gems;
-  if (gems < LOOTBOX_COSTS[lootboxID]) {
-    throw new LootboxOpenError("Not enough gems");
-  }
-
-  // TODO: needs to actually subtract gems from user in db
-  user.gems -= LOOTBOX_COSTS[lootboxID];
-
-  return new Cat(LOOTBOX_RARITY_FUNCTIONS[lootboxID]);
 }

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.7",
         "bcrypt": "^5.1.1",
+        "cookie-session": "^2.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.1",
         "express": "^4.18.2",
@@ -584,10 +585,49 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-session": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.1.0.tgz",
+      "integrity": "sha512-u73BDmR8QLGcs+Lprs0cfbcAPKl2HnPcjpwRXT41sEV4DRJ2+W0vJEEZkG31ofkx+HZflA70siRIjiTdIodmOQ==",
+      "dependencies": {
+        "cookies": "0.9.1",
+        "debug": "3.2.7",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cookie-session/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/cookie-session/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1484,6 +1524,17 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1833,6 +1884,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2373,6 +2432,14 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "engines": {
+        "node": ">=0.6.x"
       }
     },
     "node_modules/type-check": {

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.4.1",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
+        "lusca": "^1.7.0",
         "mongodb": "^6.3.0",
         "random": "^4.1.0"
       },
@@ -1587,6 +1588,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "dependencies": {
+        "tsscmp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/make-dir": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
+    "lusca": "^1.7.0",
     "mongodb": "^6.3.0",
     "random": "^4.1.0"
   },

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "axios": "^1.6.7",
     "bcrypt": "^5.1.1",
+    "cookie-session": "^2.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
     "express": "^4.18.2",

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -2,7 +2,6 @@ import express, { json as _json } from 'express';
 import cors from 'cors';
 import axios from 'axios';
 import lusca from 'lusca';
-import { ObjectId } from 'mongodb';
 
 import RateLimit from 'express-rate-limit';
 const limiter = RateLimit({
@@ -12,7 +11,7 @@ const limiter = RateLimit({
 
 import session from 'cookie-session'
 
-import { getDb, connectToServer } from './db/conn.js';
+import { connectToServer } from './db/conn.js';
 import * as canvas from './canvas.js';
 import * as lootbox from './lootbox.js';
 import Cat from "./cat.js";
@@ -218,26 +217,13 @@ app.post('/logout', async (req, res) => {
 
 app.post('/buyLootbox', limiter, async (req, res) => {
   const lootboxID = parseInt(req.body.lootboxID);
-  const session = req.body.session;
-
-  if (!session) {
-    return res.status(400).json({message: "Invalid session"});
-  }
   if (isNaN(lootboxID)) {
     return res.status(400).json({message: "Invalid lootbox"});
   }
 
-  const db = getDb();
-  // TODO: This is not how we should get the current session. When sessions are implemented, this will use a token.
-  const user = await db.findOne({"_id" : { $eq: new ObjectId(session) }});
-  
-  if (!user) {
-    return res.status(400).json({message: "Invalid user"});
-  }
-
   try {
-    const cat = lootbox.buyLootbox(lootboxID, user);
-    return res.status(200).json(cat);
+    const purchased = CatCorpUser.buyLootbox(session, lootboxID);
+    return res.status(200).json(purchased);
   } catch (error) {
     if (error instanceof lootbox.LootboxOpenError) {
       return res.status(400).json({ message: error.message });

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -1,6 +1,7 @@
 import express, { json as _json } from 'express';
 import cors from 'cors';
 import axios from 'axios';
+import lusca from 'lusca';
 import { ObjectId } from 'mongodb';
 
 import RateLimit from 'express-rate-limit';
@@ -26,6 +27,13 @@ app.use(session({
   name: 'session',
   secret: SESSION_SECRET,
   maxAge: 24 * 60 * 60 * 1000, // 1 day
+}))
+app.use(lusca({
+  csrf: true,
+  xframe: 'SAMEORIGIN',
+  xssProtection: true,
+  nosniff: true,
+  referrerPolicy: 'same-origin'
 }))
 
 app.use((req, res, next) => {

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -188,7 +188,7 @@ app.post('/cashNewSubmissions', limiter, async (req, res) => {
 
     return [c.id, c.name, newAssignments, newSubmissions]
   }))
-  const gainz = await CatCorpUser.cashSubmissions(userId, newCourses);
+  const gainz = await CatCorpUser.cashSubmissions(req.session, newCourses);
 
   return res.status(200).json({courses: newCourses, gainedGems: gainz});
 })

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -21,7 +21,8 @@ import * as CatCorpUser from './user.js';
 const SESSION_SECRET = process.env.SESSION_SECRET
 
 const app = express();
-app.use(cors({ origin: true, credentials: true }));
+const httpLocalhost = /^http:\/\/localhost:[0-9]{1,5}$/;
+app.use(cors({ origin: ["https://catcorp.vercel.app", "https://catcorporation.vercel.app", httpLocalhost], credentials: true }));
 app.use(_json());
 app.use(session({
   name: 'session',
@@ -296,7 +297,7 @@ app.get('/randomCat', async (req, res) => {
 });
 
 app.get('/', async (req, res) => {
-  res.status(200).json({ message: "hello!" });
+  res.json({ csrfToken: req.csrfToken() });
 });
 
 

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -28,6 +28,11 @@ app.use(session({
   maxAge: 24 * 60 * 60 * 1000, // 1 day
 }))
 
+app.use((req, res, next) => {
+  CatCorpUser.renewSession(req.session);
+  next();
+})
+
 axios.defaults.baseURL = 'https://ufl.instructure.com/api/v1';
 axios.defaults.headers.common['Accept'] = "application/json+canvas-string-ids";
 axios.defaults.headers.post['Content-Type'] = 'application/json';
@@ -169,6 +174,7 @@ app.post('/loginUser', limiter, async (req, res) => {
 
     req.session.ccUserId = user._id
     req.session.canvasKey = apiKey
+    CatCorpUser.renewSession(req.session);
 
     var userId = await CatCorpUser.getCanvasUserId(req.session);
     if (userId && userId !== keyCanvasUser.id) {
@@ -235,6 +241,11 @@ app.post('/registerAccount', limiter, async (req, res) => {
   const userId = await CatCorpUser.registerAccount(username, password)
   return res.status(200).json({message: "User registered", userId: userId});
 });
+
+app.post('/logout', async (req, res) => {
+  req.session = null;
+  res.status(200).json({message: "Logged out"});
+})
 
 app.post('/buyLootbox', limiter, async (req, res) => {
   const lootboxID = parseInt(req.body.lootboxID);

--- a/Backend/user.js
+++ b/Backend/user.js
@@ -1,0 +1,84 @@
+import { ObjectId } from 'mongodb'
+import bcrypt from 'bcrypt'
+import { getDb } from './db/conn.js'
+import * as canvas from './canvas.js'
+
+export async function checkUsernameAvailable(username) {
+  const user = await getDb().findOne({ "username": { $eq: username } })
+  return user === null
+}
+
+// This function does NOT do any checks for unique usernames, etc.
+export async function registerAccount(username, password) {
+  const hashedPassword = await bcrypt.hash(password, 10);
+  const user = await getDb().insertOne({ "username": username, "password": hashedPassword, "lastLogin": Date.now(), "gems": 0 })
+  return user.insertedId
+}
+
+// Returns the user object if the credentials are valid, or null if they are not.
+export async function verifyCredentials(username, password) {
+  const users = await getDb().find({ "username": { $eq: username } })
+  const usersArr = await users.toArray()
+  if (usersArr.length === 0) return null
+
+  let matchedUser = null
+  usersArr.forEach(user => {
+    if (bcrypt.compare(password, user.password)) {
+      matchedUser = user
+    }
+  })
+
+  return matchedUser
+}
+
+async function setUserProperty(session, property, value) {
+  const userId = session.ccUserId
+  if (!userId) return false
+  const objId = new ObjectId(String(userId))
+
+  const updates = {}
+  updates[property] = value
+  const updated = await getDb().updateOne({ "_id": { $eq: objId } }, { $set: updates })
+  return updated.modifiedCount === 1
+}
+
+export async function getUserDataFromSession(session) {
+  const userId = session.ccUserId
+  if (!userId) return false
+  const objId = new ObjectId(String(userId))
+  const user = await getDb().findOne({ "_id": { $eq: objId } })
+  return user
+}
+
+export async function updateLastLogin(session) {
+  return setUserProperty(session, "lastLogin", Date.now())
+}
+
+// Sets the Canvas user ID for the user in the database.
+// If force is true, it will overwrite the existing value. Otherwise, it will only set it if it's not already set.
+// Returns true if the value was set, false if it was not.
+export async function setCanvasUserId(session, canvasUserId, force = false) {
+  if (!force) {
+    const user = await getUserDataFromSession(session)
+    if (user !== null && user.canvasUserId !== null) return false
+  }
+  return setUserProperty(session, "canvasUser", canvasUserId)
+}
+
+// Gets the Canvas user ID for the user in the database.
+// If not set, then try to set it using the key from the session.
+// Returns the Canvas user ID if it's set (or was set just now), or null if it's not.
+export async function getCanvasUserId(session) {
+  const user = await getUserDataFromSession(session)
+  if (!user) return null
+  if (user.canvasUserId) return user.canvasUserId
+
+  const canvasKey = session.canvasKey
+  if (!canvasKey) return null
+  const canvasUser = await canvas.getUser(canvasKey)
+  const canvasUserId = canvasUser.id
+  if (!canvasUserId) return null
+
+  setCanvasUserId(session, canvasUserId, true)
+  return canvasUserId
+}

--- a/Backend/user.js
+++ b/Backend/user.js
@@ -31,6 +31,10 @@ export async function verifyCredentials(username, password) {
   return matchedUser
 }
 
+export function renewSession(session) {
+  if (session && session.ccUserId) session.currentMinute = Math.floor(Date.now() / 60e3)
+}
+
 async function setUserProperty(session, property, value) {
   const userId = session.ccUserId
   if (!userId) return false

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -58,6 +58,18 @@ COURSE STORAGE - NEW MODEL
   ]
 */
 
+  async function logout() {
+    try {
+      await axios.post(`/logout`);
+      setUserData(null);
+      setUserId(null);
+      setCourses(null);
+      setOverlay("login")
+    } catch (e) {
+      console.log("logout failed");
+    }
+  }
+
 
   useEffect(() => {
     if (courses) {
@@ -95,6 +107,7 @@ COURSE STORAGE - NEW MODEL
           : 
             <h2>Finishing up...</h2>
           }
+          <button onClick={logout}>Logout</button>
         </div>
       }
       </div>

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -4,13 +4,30 @@ import './css/App.css'
 import Login from "./Login"
 // import Rewards from "./Rewards"
 
-axios.defaults.headers.post['Content-Type'] = 'application/json'; //is this needed in this file?
+axios.defaults.baseURL = 'http://localhost:3500';
+axios.defaults.headers.post['Content-Type'] = 'application/json';
+axios.defaults.withCredentials = true;
+
+let initialUserData;
+let initialUserId;
+let initialCourses;
+try {
+  // TODO: Maybe this isn't the best place to put this; might move to an effect if we want to show loading indicators
+  const result = await axios.get(`/getAccountInfo`);
+  initialUserData = result.data.userData;
+  initialUserId = result.data.canvasUserId;
+  initialCourses = result.data.courses;
+} catch (e) {
+  initialUserData = null;
+  initialUserId = null;
+  initialCourses = null;
+}
 
 function App() {
-  const [courses, setCourses] = useState(null);
-  const [userId, setUserId] = useState(null); //canvas user id
-  const [userData, setUserData] = useState(null); //from db
-  const [apiKey, setApiKey] = useState(null)
+  const [courses, setCourses] = useState(initialCourses);
+  const [userId, setUserId] = useState(initialUserId); //canvas user id
+  const [userData, setUserData] = useState(initialUserData); //from db
+  const [apiKey, setApiKey] = useState("")
   const [overlay, setOverlay] = useState("login")
 
 //due_at, points_possible, has_submitted_submissions, name, 
@@ -47,7 +64,6 @@ COURSE STORAGE - NEW MODEL
       setOverlay("home")
     }
   }, [courses])
-
 
   return (
     <div>

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -13,10 +13,12 @@ let initialUserId;
 let initialCourses;
 try {
   // TODO: Maybe this isn't the best place to put this; might move to an effect if we want to show loading indicators
-  const result = await axios.get(`/getAccountInfo`);
-  initialUserData = result.data.userData;
-  initialUserId = result.data.canvasUserId;
-  initialCourses = result.data.courses;
+  const csrfTokenResp = await axios.get(`/`);
+  axios.defaults.headers.common['X-CSRF-Token'] = csrfTokenResp.data.csrfToken;
+  const accInfoResp = await axios.get(`/getAccountInfo`);
+  initialUserData = accInfoResp.data.userData;
+  initialUserId = accInfoResp.data.canvasUserId;
+  initialCourses = accInfoResp.data.courses;
 } catch (e) {
   initialUserData = null;
   initialUserId = null;

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -13,12 +13,14 @@ let initialUserId;
 let initialCourses;
 try {
   // TODO: Maybe this isn't the best place to put this; might move to an effect if we want to show loading indicators
-  const csrfTokenResp = await axios.get(`/`);
-  axios.defaults.headers.common['X-CSRF-Token'] = csrfTokenResp.data.csrfToken;
+  const initialResp = await axios.get(`/`);
+  axios.defaults.headers.common['X-CSRF-Token'] = initialResp.data.csrfToken;
+
+  const cashResp = await axios.post(`/cashNewSubmissions`);
   const accInfoResp = await axios.get(`/getAccountInfo`);
   initialUserData = accInfoResp.data.userData;
-  initialUserId = accInfoResp.data.canvasUserId;
-  initialCourses = accInfoResp.data.courses;
+  initialUserId = accInfoResp.data.userId;
+  initialCourses = cashResp.data.courses;
 } catch (e) {
   initialUserData = null;
   initialUserId = null;

--- a/Frontend/src/Login.jsx
+++ b/Frontend/src/Login.jsx
@@ -29,20 +29,18 @@ export default function Login({apiKey, setApiKey, setUserData, setUserId, setCou
 
         setLoginResponse(`Logging in user ${username}...`);
 
-        const result = await axios.post(`/loginUser`, {
+        await axios.post(`/loginUser`, {
           username: username,
           password: password,
           apiKey: currentKey
         });
-
-        console.log(result);
+        const cashResp = await axios.post(`/cashNewSubmissions`);
+        const accInfoResp = await axios.get(`/getAccountInfo`);
         
-        setUserData(result.data.userData);
-        setUserId(result.data.userId);
-        setCourses(result.data.courses);
+        setUserData(accInfoResp.data.userData);
+        setUserId(accInfoResp.data.userId);
+        setCourses(cashResp.data.courses);
         console.log("logged in");
-
-        
       } catch (e) {
         if (e.response) {
           console.log(e.response.data.message);

--- a/Frontend/src/Login.jsx
+++ b/Frontend/src/Login.jsx
@@ -8,7 +8,6 @@ import exist_user from "./img/Existing_User.png"
 import PropTypes from "prop-types";
 import "./css/Login.css"
 
-const API_URL = "http://localhost:3500"
 export default function Login({apiKey, setApiKey, setUserData, setUserId, setCourses}) {
   const [username, setUser] = useState("");
   const [password, setPassword] = useState("");
@@ -30,7 +29,7 @@ export default function Login({apiKey, setApiKey, setUserData, setUserId, setCou
 
         setLoginResponse(`Logging in user ${username}...`);
 
-        const result = await axios.post(`${API_URL}/loginUser`, {
+        const result = await axios.post(`/loginUser`, {
           username: username,
           password: password,
           apiKey: currentKey
@@ -58,7 +57,7 @@ export default function Login({apiKey, setApiKey, setUserData, setUserId, setCou
       setLoginResponse(`Registering user ${username}...`);
 
       try {
-        await axios.post(`${API_URL}/registerAccount`, {
+        await axios.post(`/registerAccount`, {
           username: username,
           password: password
         })


### PR DESCRIPTION
Introduce user sessions - now you won't get logged out on refresh

- New endpoint: `/logout` - destroys current session
- New endpoint: `/getAccountInfo` - for if you're already logged in (should `/login`'s similar logic be removed from there?)
- All endpoints now check the session cookie for the Canvas API key, user IDs instead of looking in the body/query
- Refactoring: several functions moved into new `user.js` file that do actions based on the provided session

To do:
- [x] review CORS settings
- [x] may want to wait for other PRs to merge first
max wuz here