### PR TITLE
Put staging deployments in CORS allowed origins

### DIFF
--- a/Backend/server.js
+++ b/Backend/server.js
@@ -21,7 +21,8 @@ const SESSION_SECRET = process.env.SESSION_SECRET
 
 const app = express();
 const httpLocalhost = /^http:\/\/localhost:[0-9]{1,5}$/;
-app.use(cors({ origin: ["https://catcorp.vercel.app", "https://catcorporation.vercel.app", httpLocalhost], credentials: true }));
+const stagingVercelDeployments = /^https:\/\/catcorp-frontend-.*-kenneths-projects-[a-z0-9]{8}\.vercel\.app$/;
+app.use(cors({ origin: ["https://catcorp.vercel.app", "https://catcorporation.vercel.app", httpLocalhost, stagingVercelDeployments], credentials: true }));
 app.use(_json());
 app.use(session({
   name: 'session',


### PR DESCRIPTION
Vercel staging deployments (like the one that should be generated by this PR) should now work with the backend properly without getting blocked by CORS.

to test:
1. run backend locally
2. check that the Vercel deployment below works when logging in 