### PR TITLE
Use locks to avoid race conditions with user updates

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "catcorp-backend",
       "version": "0.0.0",
       "dependencies": {
+        "async-lock": "^1.4.1",
         "axios": "^1.6.7",
         "bcrypt": "^5.1.1",
         "cookie-session": "^2.1.0",
@@ -1640,6 +1641,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -9,6 +9,7 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
+    "async-lock": "^1.4.1",
     "axios": "^1.6.7",
     "bcrypt": "^5.1.1",
     "cookie-session": "^2.1.0",

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -3,6 +3,9 @@ import cors from 'cors';
 import axios from 'axios';
 import lusca from 'lusca';
 
+import AsyncLock from 'async-lock';
+const lock = new AsyncLock();
+
 import RateLimit from 'express-rate-limit';
 const limiter = RateLimit({
   windowMs: 15 * 60 * 1000,
@@ -188,21 +191,25 @@ app.post('/cashNewSubmissions', limiter, async (req, res) => {
     return res.status(401).json({message: "Invalid session!"});
   }
 
-  try {
-    const userData = await CatCorpUser.getUserDataFromSession(req.session);
-    const courses = await canvas.getCourses(canvasKey);
-    const newCourses = await Promise.all(courses.map(async (c) => {
-      const newAssignments = await canvas.getAssignments(canvasKey, c.id)
-      const newSubmissions = await canvas.getNewSubmissions(canvasKey, c.id, userData.lastLogin)
-      const weeklySubmissions = await canvas.getNewSubmissions(canvasKey, c.id, getLastSundayNight(Date.now()))
+  const result = await lock.acquire(userId, async () => {
+    try {
+      const userData = await CatCorpUser.getUserDataFromSession(req.session);
+      const courses = await canvas.getCourses(canvasKey);
+      const newCourses = await Promise.all(courses.map(async (c) => {
+        const newAssignments = await canvas.getAssignments(canvasKey, c.id)
+        const newSubmissions = await canvas.getNewSubmissions(canvasKey, c.id, userData.lastLogin)
+        const weeklySubmissions = await canvas.getNewSubmissions(canvasKey, c.id, getLastSundayNight(Date.now()))
 
-      return [c.id, c.name, newAssignments, newSubmissions, weeklySubmissions]
-    }))
-    const gainz = await CatCorpUser.cashSubmissions(req.session, newCourses);
-    return res.status(200).json({courses: gainz[0], gainedGems: gainz[1], bossResults: gainz[2]});
-  } catch (error) {
-    return res.status(error.status).json({ error: error.message });
-  }
+        return [c.id, c.name, newAssignments, newSubmissions, weeklySubmissions]
+      }))
+      const gainz = await CatCorpUser.cashSubmissions(req.session, newCourses);
+      return res.status(200).json({courses: gainz[0], gainedGems: gainz[1], bossResults: gainz[2]});
+    } catch (error) {
+      return res.status(error.status).json({ error: error.message });
+    }
+  })
+
+  return result
 })
 
 function getLastSundayNight(date) { //inputs unix timestamp, output unix timestamp
@@ -234,19 +241,23 @@ app.post('/logout', async (req, res) => {
 })
 
 app.post('/buyLootbox', limiter, async (req, res) => {
+  const userID = req.session.ccUserId;
   const lootboxID = parseInt(req.body.lootboxID);
-  if (isNaN(lootboxID)) {
+  if (isNaN(lootboxID) || !userID) {
     return res.status(400).json({message: "Invalid lootbox"});
   }
 
-  try {
-    const purchased = await CatCorpUser.buyLootbox(req.session, lootboxID);
-    return res.status(200).json(purchased);
-  } catch (error) {
-    if (error instanceof lootbox.LootboxOpenError) {
-      return res.status(400).json({ message: error.message });
+  const result = await lock.acquire(userID, async () => {
+    try {
+      const purchased = await CatCorpUser.buyLootbox(req.session, lootboxID);
+      return res.status(200).json(purchased);
+    } catch (error) {
+      if (error instanceof lootbox.LootboxOpenError) {
+        return res.status(400).json({ message: error.message });
+      }
     }
-  }
+  })
+  return result
 });
 
 app.get('/randomCat', async (req, res) => {

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -14,20 +14,28 @@ function App() {
   const [userData, setUserData] = useState(null); //from db
   const [overlay, setOverlay] = useState("login")
 
-  function onLoginDataReceived(newCourses, newUserData) {
-    setCourses(newCourses)
+  async function onLoginDataReceived(newUserData) {
     setUserData(newUserData)
-    let newSubmissionsExist = false
-    for (let course of newCourses) {
-      if (course[3].length > 0) {
-        newSubmissionsExist = true
-        break
+    setOverlay("home")
+
+    try {
+      const cashResp = await axios.post(`/cashNewSubmissions`);
+      setCourses(cashResp.data.courses);
+      newUserData.gems += cashResp.data.gainedGems
+      setUserData(newUserData)
+
+      let newSubmissionsExist = false
+      for (let course of cashResp.data.courses) {
+        if (course[3].length > 0) {
+          newSubmissionsExist = true
+          break
+        }
       }
-    }
-    if (newSubmissionsExist) {
-      setOverlay("rewards")
-    } else {
-      setOverlay("home")
+      if (newSubmissionsExist) {
+        setOverlay("rewards")
+      }
+    } catch (e) {
+      console.log("Failed to cash submissions");
     }
   }
 

--- a/Frontend/src/Home.jsx
+++ b/Frontend/src/Home.jsx
@@ -49,8 +49,8 @@ function Home({ userData, setUserData, courses, setCourses, overlay, setOverlay 
       : overlay == "store" ? 
         <Store setOverlay={setOverlay} userData={userData} setUserData={setUserData}/>
       : <></>
-    }
-      <button onClick={() => logout()} style={{position:'absolute',bottom:0, right:0}}>
+      }
+      <button onClick={() => logout()} style={{position:'absolute',top:0, right:0}}>
         <img src={logoutButton}></img>      
       </button>
       <div>

--- a/Frontend/src/Home.jsx
+++ b/Frontend/src/Home.jsx
@@ -31,8 +31,8 @@ function Home({ userData, setUserData, courses, setCourses, overlay, setOverlay 
       setWidth(window.innerWidth);
       setHeight(window.innerHeight);
     }
-
     window.addEventListener('resize', setDimensions)
+
     return () => {
       window.removeEventListener('resize', setDimensions)
     }

--- a/Frontend/src/Login.jsx
+++ b/Frontend/src/Login.jsx
@@ -20,14 +20,16 @@ export default function Login({onLoginDataReceived}) {
   const [usingSession, setUsingSession] = useState(true)
 
   useEffect(() => {
+    let ignore = false
+
     async function tryLogin() {
       try {
         await getCsrfToken();
 
-        const cashResp = await axios.post(`/cashNewSubmissions`);
         const accInfoResp = await axios.get(`/getAccountInfo`);
-        onLoginDataReceived(cashResp.data.courses, accInfoResp.data.userData)
-        console.log(cashResp.data)
+        if (!ignore) {
+          onLoginDataReceived(accInfoResp.data.userData)
+        }
       } catch (e) {
         // no session yet - just ignore
       } finally {
@@ -36,6 +38,10 @@ export default function Login({onLoginDataReceived}) {
     }
 
     tryLogin();
+
+    return () => {
+      ignore = true
+    }
   }, [onLoginDataReceived]);
 
   const handleSubmit = (e) => {
@@ -58,10 +64,9 @@ export default function Login({onLoginDataReceived}) {
           password: password,
           apiKey: currentKey
         });
-        const cashResp = await axios.post(`/cashNewSubmissions`);
         const accInfoResp = await axios.get(`/getAccountInfo`);
         
-        onLoginDataReceived(cashResp.data.courses, accInfoResp.data.userData)
+        onLoginDataReceived(accInfoResp.data.userData)
         console.log("logged in");
       } catch (e) {
         if (e.response) {

--- a/Frontend/src/css/App.css
+++ b/Frontend/src/css/App.css
@@ -23,8 +23,7 @@ body {
 }
 
 .back, .backOverlay {
-  border-right:1px solid black;
-  border-bottom:1px solid black;
+  border-right:1px solid rgba(0, 0, 0, .125);
   position:absolute;
   top: 0;
   left: 0;
@@ -42,6 +41,7 @@ body {
 .backOverlay {
   background-color: transparent;
   z-index: 100001;
+  border-right: none;
 }
 
 .back, .backOverlay > img {


### PR DESCRIPTION
Updates such as from lootbox purchases and cashing submissions could previously double (or more) reward/penalize if the endpoint was hit multiple times. This adds locks to those endpoints to try to avoid this.