### PR TITLE
Trust reverse proxies for rate limits

### DIFF
--- a/Backend/server.js
+++ b/Backend/server.js
@@ -39,6 +39,7 @@ app.use(lusca({
   nosniff: true,
   referrerPolicy: 'same-origin'
 }))
+app.set('trust proxy', 1)
 
 app.use((req, res, next) => {
   CatCorpUser.renewSession(req.session);


### PR DESCRIPTION
This fixes one issue with the Vercel deployment, but I don't think it will completely fix the functionality yet.